### PR TITLE
Optimize SQL query to select countries with GDP exceeding Europe's maximum

### DIFF
--- a/sqlzoo/BiggerThanEurope.sql
+++ b/sqlzoo/BiggerThanEurope.sql
@@ -1,7 +1,8 @@
-SELECT name 
-FROM world
-WHERE gdp > 
-	  (SELECT 
-	   MAX(gdp) 
-	   FROM world 
-	   WHERE continent LIKE 'Europe')
+SELECT w.name
+FROM world w
+JOIN (
+    SELECT MAX(w2.gdp) AS max_gdp
+    FROM world w2
+    WHERE w2.continent = 'Europe'
+) europe_max
+ON w.gdp > europe_max.max_gdp;


### PR DESCRIPTION
The query optimizes the selection process by first determining Europe's maximum GDP in a subquery. This result (max_gdp) is then used to filter countries in the main query, ensuring that only countries with GDP values higher than Europe's highest GDP are returned. This approach avoids redundant calculations and improves query efficiency by leveraging a subquery result directly in the main query's filtering condition.